### PR TITLE
compute indicators with specific indicators

### DIFF
--- a/app/admin/api.py
+++ b/app/admin/api.py
@@ -28,7 +28,7 @@ async def add_historic_data(request: request_body.SymbolRequest, client: Client 
     """
     symbols = request.symbols  
     start_date = request.start_date or '01/01/2020'
-    end_date = request.end_date or date.today.strftime("%d/%m/%Y")
+    end_date = request.end_date or date.today().strftime("%d/%m/%Y")
 
     
     return await admin_service.add_data_for_symbol(client, symbols, start_date, end_date)

--- a/app/admin/request_body.py
+++ b/app/admin/request_body.py
@@ -1,4 +1,5 @@
 from datetime import date
+from typing import Optional
 from pydantic import BaseModel
 
 class SymbolRequest(BaseModel):
@@ -9,5 +10,5 @@ class SymbolRequest(BaseModel):
     @param end_date: date - The end date for the data request.
     """
     symbols: list[str] 
-    start_date : date
-    end_date : date
+    start_date : Optional[date]
+    end_date : Optional[date]

--- a/app/admin/service.py
+++ b/app/admin/service.py
@@ -95,7 +95,7 @@ class AdminService():
                     failed['symbol'].append(symbol)
             else:
                 failed['symbol'].append(symbol)
-        return {"status": "success", "symbols": symbols}
+        return {"status": "success", "failed": failed}
 
 
     async def validate_symbol(self, client:Client, symbol:str):

--- a/app/function_registry.py
+++ b/app/function_registry.py
@@ -1,0 +1,44 @@
+import pandas as pd
+import numpy as np
+from fastapi import Request, Depends
+from clickhouse_connect.driver.client import Client
+from app.dependency import get_db_client  # use your existing dependency
+
+# Local implementations of functions
+PYTHON_FUNCTIONS = {
+    "sma": lambda s, n: s.rolling(window=int(n), min_periods=int(n)).mean(),
+    "ema": lambda s, n: s.ewm(span=int(n), adjust=False).mean(),
+    "wilder": lambda s, n: s.ewm(alpha=1/int(n), adjust=False, min_periods=int(n)).mean(),
+    "diff": lambda s: s.diff() if isinstance(s, pd.Series) else None,
+    "cumsum": lambda s: s.cumsum(),
+    "max": lambda a, b: pd.Series(np.maximum(a, b), index=a.index if isinstance(a, pd.Series) else None),
+    "min": lambda a, b: pd.Series(np.minimum(a, b), index=a.index if isinstance(a, pd.Series) else None),
+    "abs": lambda s: s.abs(),
+    "shift": lambda s, n: s.shift(int(n)),
+    "rolling_max": lambda s, n: s.rolling(window=int(n), min_periods=int(n)).max(),
+    "rolling_min": lambda s, n: s.rolling(window=int(n), min_periods=int(n)).min(),
+    "stdev": lambda s, n: s.rolling(window=int(n), min_periods=int(n)).std(),
+}
+
+def load_function_registry(db: Client) -> dict:
+    """
+    Load the indicator function registry from the database.
+    @param db - ClickHouse client (injected via get_db_client).
+    @return dict mapping function name -> implementation.
+    """
+    rows = db.query(
+        "SELECT name, impl_type FROM indicator_functions"
+    ).result_rows
+
+    registry = {}
+    for name, impl_type in rows:
+        if impl_type == "python":
+            if name not in PYTHON_FUNCTIONS:
+                raise ValueError(f"No Python implementation found for {name}")
+            registry[name] = PYTHON_FUNCTIONS[name]
+        elif impl_type == "sql":
+            # Placeholder for SQL-executable functions
+            registry[name] = lambda *args: f"{name}({','.join(map(str,args))})"
+        else:
+            raise ValueError(f"Unsupported impl_type {impl_type} for {name}")
+    return registry

--- a/app/indicators/compute.py
+++ b/app/indicators/compute.py
@@ -1,0 +1,96 @@
+from typing import List
+from app.indicators.eval_engine import safe_eval, validate_expr
+from app.indicators.repo import IndicatorBase
+from app.models import OHLCVData
+import re
+import pandas as pd
+
+class ComputeEngine:
+
+    def execute_indicator(self,definition: dict, df, registry: dict, params: dict = None):
+        """
+        Execute indicator using exec_plan from DB.
+        df: pandas.DataFrame with open_price, high_price, low_price, close_price, volume
+        registry: preloaded function registry (request.app.state.func_registry)
+        params: runtime overrides
+        """
+        exec_plan = definition.get("exec_plan", {})
+        if not exec_plan:
+            raise ValueError("Indicator missing exec_plan")
+        
+        env = {
+            "open_price": df["open_price"],
+            "high_price": df["high_price"],
+            "low_price": df["low_price"],
+            "close_price": df["close_price"],
+            "volume": df["volume"],
+        }
+
+        merged_params = {**(definition.get("parameters") or {}), **(params or {})}
+        env.update(merged_params)
+        for key, val in definition.get("parameters", {}).items():
+            env[key] = val
+
+
+        if any(v is None for v in env.values()):
+            raise ValueError(f"Environment has None values before evaluating {step['name']}")
+        steps = exec_plan.get("steps", [])
+        for step in steps:
+            name, expr = step["name"], step["expr"]
+            validate_expr(expr, registry, list(env.keys()))
+            env[name] = safe_eval(expr, env, registry)
+
+        formula = exec_plan["formula"]
+        validate_expr(formula, registry, list(env.keys()))
+        return safe_eval(formula, env, registry)
+    
+
+
+    def parse_timeframe(self,tf: str) -> str:
+        """
+        Convert timeframe strings (1m, 5m, 1h, 1d, 1w, 1M) to pandas resample rules.
+        """
+        match = re.match(r"^(\d+)([mhdwM])$", tf)
+        if not match:
+            raise ValueError(f"Invalid timeframe: {tf}")
+
+        num, unit = match.groups()
+        unit_map = {
+            "m": "min",
+            "h": "H",
+            "d": "D",
+            "w": "W",
+            "M": "M"  # monthly
+        }
+        return f"{num}{unit_map[unit]}"
+
+    def resample_ohlcv(self,df: pd.DataFrame, timeframe: str) -> pd.DataFrame:
+        """
+        Resample OHLCV data dynamically based on timeframe string.
+        """
+        rule = self.parse_timeframe(timeframe)
+
+        df["timestamp"] = pd.to_datetime(df["timestamp"])
+        df = df.set_index("timestamp")
+
+        ohlcv = df.resample(rule).agg({
+            "open_price": "first",
+            "high_price": "max",
+            "low_price": "min",
+            "close_price": "last",
+            "volume": "sum"
+        }).dropna()
+
+        ohlcv.reset_index(inplace=True)
+        ohlcv.rename(columns={"index": "timestamp"}, inplace=True)
+        return ohlcv
+
+
+            
+
+
+                
+
+
+
+            

--- a/app/indicators/compute.py
+++ b/app/indicators/compute.py
@@ -31,7 +31,6 @@ class ComputeEngine:
         for key, val in definition.get("parameters", {}).items():
             env[key] = val
 
-
         if any(v is None for v in env.values()):
             raise ValueError(f"Environment has None values before evaluating {step['name']}")
         steps = exec_plan.get("steps", [])

--- a/app/indicators/eval_engine.py
+++ b/app/indicators/eval_engine.py
@@ -3,13 +3,16 @@ import ast
 ALLOWED_NODES = {
     ast.Expression, ast.Call, ast.BinOp, ast.UnaryOp, ast.Name, ast.Load,
     ast.Add, ast.Sub, ast.Mult, ast.Div, ast.Pow, ast.Mod, ast.USub,
-    ast.Constant, ast.Tuple, ast.List
+    ast.Constant, ast.Tuple, ast.List,
+    ast.ListComp, ast.comprehension
 }
+
 
 class ExpressionValidator(ast.NodeVisitor):
     def __init__(self, allowed_funcs, allowed_vars):
         self.allowed_funcs = allowed_funcs
         self.allowed_vars = allowed_vars
+        self.local_vars = set()
 
     def visit_Call(self, node):
         if not isinstance(node.func, ast.Name):
@@ -21,8 +24,28 @@ class ExpressionValidator(ast.NodeVisitor):
             self.visit(arg)
 
     def visit_Name(self, node):
-        if node.id not in self.allowed_vars:
-            raise ValueError(f"Unknown variable '{node.id}'")
+        if isinstance(node.ctx, ast.Load):  # using a variable
+            if node.id not in self.allowed_vars and node.id not in self.local_vars:
+                raise ValueError(f"Unknown variable '{node.id}'")
+        elif isinstance(node.ctx, ast.Store):  # defining a variable
+            self.local_vars.add(node.id)
+
+    def visit_ListComp(self, node):
+            for gen in node.generators:
+                self.visit(gen)      # visit_comprehension will add loop var
+            self.visit(node.elt)
+
+
+
+
+
+    def visit_comprehension(self, node):
+        # explicitly register loop variable (f in "for f in fib_levels")
+        if isinstance(node.target, ast.Name):
+            self.local_vars.add(node.target.id)
+        self.visit(node.iter)
+        for if_clause in node.ifs:
+            self.visit(if_clause)
 
     def generic_visit(self, node):
         if type(node) not in ALLOWED_NODES:
@@ -34,7 +57,6 @@ def validate_expr(expr: str, funcs: dict, vars: list[str]):
     """Validate expression AST: allowed functions + allowed variables"""
     tree = ast.parse(expr, mode="eval")
     ExpressionValidator(funcs, vars).visit(tree)
-
 
 
 
@@ -70,13 +92,32 @@ class SafeEval(ast.NodeVisitor):
         val = self.visit(node.operand)
         if isinstance(node.op, ast.USub): return -val
         return val
+    
+    def visit_ListComp(self, node):
+        results = []
+        saved_env = self.env.copy()
+
+        for gen in node.generators:
+            iterable = self.visit(gen.iter)
+            for val in iterable:
+                if isinstance(gen.target, ast.Name):
+                    self.env[gen.target.id] = val
+                else:
+                    raise ValueError("Unsupported target in comprehension")
+
+                elt_val = self.visit(node.elt)
+                results.append(elt_val)
+
+        self.env = saved_env
+        return results
+
 
 
 def safe_eval(expr: str, env: dict, registry: dict):
     """Safely evaluate expression string with env + registry"""
     tree = ast.parse(expr, mode="eval")
     evaluator = SafeEval(env, registry)
-    result = evaluator.visit(tree.body)   # <<-- use .body instead of tree
+    result = evaluator.visit(tree.body)   
     if result is None:
         raise ValueError(f"Expression '{expr}' evaluated to None")
     return result

--- a/app/indicators/eval_engine.py
+++ b/app/indicators/eval_engine.py
@@ -1,0 +1,84 @@
+import ast
+
+ALLOWED_NODES = {
+    ast.Expression, ast.Call, ast.BinOp, ast.UnaryOp, ast.Name, ast.Load,
+    ast.Add, ast.Sub, ast.Mult, ast.Div, ast.Pow, ast.Mod, ast.USub,
+    ast.Constant, ast.Tuple, ast.List
+}
+
+class ExpressionValidator(ast.NodeVisitor):
+    def __init__(self, allowed_funcs, allowed_vars):
+        self.allowed_funcs = allowed_funcs
+        self.allowed_vars = allowed_vars
+
+    def visit_Call(self, node):
+        if not isinstance(node.func, ast.Name):
+            raise ValueError("Only function calls allowed")
+        fname = node.func.id
+        if fname not in self.allowed_funcs:
+            raise ValueError(f"Function '{fname}' not registered")
+        for arg in node.args:
+            self.visit(arg)
+
+    def visit_Name(self, node):
+        if node.id not in self.allowed_vars:
+            raise ValueError(f"Unknown variable '{node.id}'")
+
+    def generic_visit(self, node):
+        if type(node) not in ALLOWED_NODES:
+            raise ValueError(f"Disallowed syntax: {ast.dump(node)}")
+        super().generic_visit(node)
+
+
+def validate_expr(expr: str, funcs: dict, vars: list[str]):
+    """Validate expression AST: allowed functions + allowed variables"""
+    tree = ast.parse(expr, mode="eval")
+    ExpressionValidator(funcs, vars).visit(tree)
+
+
+
+
+class SafeEval(ast.NodeVisitor):
+    def __init__(self, env, registry):
+        self.env = env
+        self.registry = registry
+
+    def visit_Call(self, node):
+        fname = node.func.id
+        args = [self.visit(a) for a in node.args]
+        result = self.registry[fname](*args)
+        return result
+
+
+    def visit_Name(self, node):
+        return self.env[node.id]
+
+    def visit_Constant(self, node):
+        return node.value
+
+    def visit_BinOp(self, node):
+        left = self.visit(node.left)
+        right = self.visit(node.right)
+        if isinstance(node.op, ast.Add): return left + right
+        if isinstance(node.op, ast.Sub): return left - right
+        if isinstance(node.op, ast.Mult): return left * right
+        if isinstance(node.op, ast.Div): return left / right
+        if isinstance(node.op, ast.Pow): return left ** right
+        raise ValueError("Unsupported operator")
+
+    def visit_UnaryOp(self, node):
+        val = self.visit(node.operand)
+        if isinstance(node.op, ast.USub): return -val
+        return val
+
+
+def safe_eval(expr: str, env: dict, registry: dict):
+    """Safely evaluate expression string with env + registry"""
+    tree = ast.parse(expr, mode="eval")
+    evaluator = SafeEval(env, registry)
+    result = evaluator.visit(tree.body)   # <<-- use .body instead of tree
+    if result is None:
+        raise ValueError(f"Expression '{expr}' evaluated to None")
+    return result
+
+

--- a/app/indicators/repo.py
+++ b/app/indicators/repo.py
@@ -24,6 +24,7 @@ class IndicatorBase(BaseModel):
     formula: str = Field(..., min_length=1)
     dependencies: Dict[str, Any] = Field(default_factory=dict)
     parameters: Dict[str, Any] = Field(default_factory=dict)
+    exec_plan:Dict[str,Any] = Field(default_factory=dict)
 
     @field_validator('dependencies')
     def dependencies_must_be_object(cls, v):

--- a/app/migrations/00003-create_indicator_functions_table.sql
+++ b/app/migrations/00003-create_indicator_functions_table.sql
@@ -1,0 +1,12 @@
+-- Create table to store available functions for indicator expressions
+
+CREATE TABLE IF NOT EXISTS indicator_functions (
+    name LowCardinality(String),          -- function name (e.g. "ema")
+    description String,                   -- human-readable doc
+    category LowCardinality(String),      -- e.g. "smoothing", "math", "oscillator"
+    arity UInt8,                          -- expected number of arguments
+    impl_type LowCardinality(String),     -- "python" or "sql"
+    expr Nullable(String),                -- optional SQL expression if impl_type="sql"
+    created_at DateTime64(3, 'UTC') DEFAULT now64()
+) ENGINE = MergeTree()
+ORDER BY (name);

--- a/app/migrations/00004-add-table.sql
+++ b/app/migrations/00004-add-table.sql
@@ -1,0 +1,3 @@
+--add column exec_plan in tech_indi table
+
+ALTER TABLE technical_indicators ADD COLUMN IF NOT EXISTS exec_plan JSON;

--- a/app/migrations/00005-alter_table.sql
+++ b/app/migrations/00005-alter_table.sql
@@ -1,0 +1,2 @@
+--alter column type in table
+ALTER TABLE technical_indicators MODIFY COLUMN exec_plan String;

--- a/test.py
+++ b/test.py
@@ -1,13 +1,17 @@
-import ccxt
+import asyncio
+from datetime import datetime
 
-# Initialize exchange
-exchange = ccxt.binance()   # you can also use ccxt.coinbase(), ccxt.kucoin(), etc.
-print(exchange.id)
-# Load markets
-markets = exchange.load_markets()
+async def task(args):
+    print(f"started {args} {datetime.now()}")
+    await asyncio.sleep(args)  
+    print(f"ended {args} {datetime.now()}")
 
-# Get list of symbols
-symbols = list(markets.keys())
+async def main():
+    # Run all tasks concurrently
+    await asyncio.gather(
+        task(1),
+        task(3),
+        task(5)
+    )
 
-print(f"Total markets: {len(symbols)}")
-print(symbols[:20])  # print first 20
+asyncio.run(main())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an endpoint to compute technical indicators with symbol, timeframe, and limit parameters; supports timeframe-based resampling and returns computed values.
  - Indicator requests now allow optional start_date and end_date.
- Bug Fixes
  - Corrected default end date when adding historic data to reliably use today’s date.
- Chores
  - Initialized function registry at app startup to enable indicator computations.
  - Database migrations: added registry for indicator functions and introduced exec_plan support for indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->